### PR TITLE
Compare push-preview as a boolean

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
       interval: weekly
       time: "04:00"
     open-pull-requests-limit: 10
+    ignore:
+      #xunit.v3 majors are migrations, not bumps: 3.x to 4.0 forced Microsoft.Testing.Platform,
+      #OutputType Exe and four package swaps. Minors and patches flow normally.
+      - dependency-name: xunit.*
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
   release:
     needs: [versioning, build]
     if: needs.versioning.outputs.release-exists == 'false'
-      && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || inputs.push-preview == 'true')
+      && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || inputs.push-preview == true)
     uses: f2calv/gha-workflows/.github/workflows/gha-release-versioning.yml@v1
     permissions:
       contents: write


### PR DESCRIPTION
The `push-preview` input is declared as a boolean but the release condition compared it to the string `'true'`.

GitHub [coerces mismatched types to a number](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#operators): a boolean `true` becomes `1` and a non-numeric string becomes `NaN`, so the comparison never matched.

Releases on the default branch were unaffected, since the first clause of the condition covers them. It was the preview path that could never fire.

Introduced when `push-preview` was normalised from a string to a boolean without updating the comparison. `yamlizr` had the same defect and is already fixed.